### PR TITLE
Typo in Zsh resource file name

### DIFF
--- a/Shell-Unix-Generic.sublime-settings
+++ b/Shell-Unix-Generic.sublime-settings
@@ -22,7 +22,7 @@
 		".screenrc",
 		".vim",
 		".vimrc",
-		".zhsrc",
+		".zshrc",
 		".zlogin",
 		".wgetrc"
 	]


### PR DESCRIPTION
Zsh resource file name should be .zshrc.
