### PR TITLE
Add .curlrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Install via [Package Control](http://wbond.net/sublime_packages/package_control)
 `.bash_prompt`
 `.bashrc`
 `.brew`
+`.curlrc`
 `.exports`
 `.functions`
 `.git`

--- a/Shell-Unix-Generic.sublime-settings
+++ b/Shell-Unix-Generic.sublime-settings
@@ -7,6 +7,7 @@
 		".bash_prompt",
 		".bashrc",
 		".brew",
+		".curlrc",
 		".exports",
 		".functions",
 		".git",


### PR DESCRIPTION
[`.curlrc`](http://curl.haxx.se/docs/manpage.html#FILES): [cURL](http://en.wikipedia.org/wiki/CURL) default configuration file.

@mattbanks: according to the [docs](http://curl.haxx.se/docs/manpage.html#-K) (haven't tested), on Windows, `_curlrc` is used instead of `.curlrc` so, you might consider adding it.
