### PR TITLE
add .zsh-theme to extensions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Install via [Package Control](https://sublime.wbond.net/)
 - `.zprofile`
 - `.zshenv`
 - `.zshrc`
+- `.zsh-theme`
 - `.zpreztorc`
 - `.xsessionrc`
 - `.wgetrc`

--- a/Shell-Unix-Generic.sublime-settings
+++ b/Shell-Unix-Generic.sublime-settings
@@ -32,6 +32,7 @@
 		".zprofile",
 		".zshenv",
 		".zshrc",
+		".zsh-theme",
 		".zpreztorc",
 		".xsessionrc",
 		".wgetrc",


### PR DESCRIPTION
.zsh-theme is a theme file extension used by oh-my-zsh 
