### PR TITLE
Remove .editorconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Install via [Package Control](https://sublime.wbond.net/)
 - `.bashrc`
 - `.brew`
 - `.curlrc`
-- `.editorconfig`
 - `.env`
 - `.envrc`
 - `.eslintignore`

--- a/Shell-Unix-Generic.sublime-settings
+++ b/Shell-Unix-Generic.sublime-settings
@@ -10,7 +10,6 @@
 		".bashrc",
 		".brew",
 		".curlrc",
-		".editorconfig",
 		".env",
 		".envrc",
 		".eslintignore",		


### PR DESCRIPTION
`.editorconfig`s are more like Ini files rather than Bash. Actually, there is [editorconfig-sublime](https://github.com/sindresorhus/editorconfig-sublime) plugin with proper syntax highlighting, but it gets overridden by `dotfiles`. It's quite annoying to manually switch syntax every time you open an `.editorconfig`.
